### PR TITLE
requirements.txt : remove json and pickle

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
-json
 requests
 bs4
-pickle
 pyqt5
 lxml


### PR DESCRIPTION
removed **json** and **pickle** modules from requirements.txt as they're already included with the python package and thus end up triggering an error while trying to install requirements .